### PR TITLE
Update current directory in inferior octave when completion starts

### DIFF
--- a/ac-octave.el
+++ b/ac-octave.el
@@ -78,7 +78,13 @@
 
 (defun ac-octave-init ()
   "Start inferior-octave in background before use ac-octave."
-  (run-octave t))
+  (run-octave t)
+  ;; Update current directory of inferior octave whenever completion starts.
+  ;; This allows local functions to be completed when user switches
+  ;; between octave buffers that are located in different directories.
+  (when (file-readable-p default-directory)
+    (inferior-octave-send-list-and-digest
+     (list (concat "cd " default-directory ";\n")))))
 
 (defun ac-octave-do-complete ()
   (interactive)


### PR DESCRIPTION
This commit allows local functions to be completed when user switches between octave buffers that are located in different directories.

For example when I open `a/a.m` file and `b/b.m` file later then while editing `b/b.m` file, functions located in `a` directory are completed. With this commit functions defined in `b` directory will be completed in this case.
