### PR TITLE
Don't check minor version if major version is > 25

### DIFF
--- a/ac-octave.el
+++ b/ac-octave.el
@@ -53,7 +53,8 @@
 
 ;; octave-inf.el merge to octave.el since emacs version 24.3.1
 ;; see issue #6: Error when require octave-inf
-(if (and (>= emacs-major-version 24) (> emacs-minor-version 3))
+(if (or (and (= emacs-major-version 24) (> emacs-minor-version 3))
+	(>= emacs-major-version 25))
     (require 'octave)
   ;; for emacs 24.3 or below
   (require 'octave-inf))


### PR DESCRIPTION
Hi!

I'm using the following version of emacs:
GNU Emacs 25.0.50.2 (x86_64-unknown-linux-gnu, GTK+ Version 3.14.3)

My minor version is 0, so it tries to require octave-inf.

I hope you don't mind, but I've made a fix.. I've never done a pull request before, so let me know if I've done anything wrong or my code is funny.

Thanks!