### PR TITLE
Fix void-variable ac-complete-octave

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ Add following lines to your init file:
 
 ```elisp
 (require 'ac-octave)
-(defun ac-octave-mode-setup ()
-  (setq ac-sources '(ac-complete-octave)))
 (add-hook 'octave-mode-hook
-          '(lambda () (ac-octave-mode-setup)))
+          '(lambda () (ac-octave-setup)))
 ```
 
 ### Note
@@ -35,6 +33,11 @@ check whether `auto-complete-mode` is running or not.
 #### `(ac-octave-init)`
 
 Start inferior-octave in background before use ac-octave.
+
+#### `(ac-octave-setup)`
+
+Add the octave completion source to the front of ‘ac-sources’.
+This affects only the current buffer.
 
 -----
 <div style="padding-top:15px;color: #d0d0d0;">

--- a/ac-octave.el
+++ b/ac-octave.el
@@ -6,7 +6,7 @@
 ;; Keywords: Octave, auto-complete, completion
 ;; Package-Requires: ((auto-complete "1.4.0"))
 ;; URL: https://github.com/coldnew/ac-octave
-;; Version: 0.6
+;; Version: 0.7
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -36,10 +36,8 @@
 ;;
 ;; ```elisp
 ;; (require 'ac-octave)
-;; (defun ac-octave-mode-setup ()
-;;   (setq ac-sources '(ac-complete-octave)))
 ;; (add-hook 'octave-mode-hook
-;;           '(lambda () (ac-octave-mode-setup)))
+;;           '(lambda () (ac-octave-setup)))
 ;; ```
 
 ;;; Note:
@@ -127,14 +125,20 @@
 
 ;;;###autoload
 (ac-define-source octave
-                  '((candidates . ac-octave-candidate)
-                    (document . ac-octave-documentation)
-                    (candidate-face . ac-octave-candidate-face)
-                    (selection-face . ac-octave-selection-face)
-                    (init . ac-octave-init)
-                    (requires . 0)
-                    (cache)
-                    (symbol . "f")))
+  '((candidates . ac-octave-candidate)
+    (document . ac-octave-documentation)
+    (candidate-face . ac-octave-candidate-face)
+    (selection-face . ac-octave-selection-face)
+    (init . ac-octave-init)
+    (requires . 0)
+    (cache)
+    (symbol . "f")))
+
+;;;###autoload
+(defun ac-octave-setup ()
+  "Add the octave completion source to the front of `ac-sources'.
+This affects only the current buffer."
+  (add-to-list 'ac-sources 'ac-source-octave))
 
 (provide 'ac-octave)
 ;;; ac-octave.el ends here


### PR DESCRIPTION
The variable `ac-complete-octave` is not generated by
`ac-define-source` macro, we should use `ac-source-octave` instead.

Fixed #11

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>